### PR TITLE
Add worldcat column back into schema

### DIFF
--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -53,7 +53,8 @@ class App extends React.Component {
             alibris: book.alibris,
             betterWorldBooks: book.betterWorldBooks,
             indieBound: book.indieBound
-          }
+          },
+          worldcat: book.worldcat
         };
         const metadata = {
           originalTitle: book.originalTitle,

--- a/seed/sqlSeed.js
+++ b/seed/sqlSeed.js
@@ -47,6 +47,7 @@ const newBook = () => {
       alibris: fake.internet.url(),
       betterWorldBooks: fake.internet.url(),
       indieBound: fake.internet.url(),
+      worldcat: fake.internet.url(),
       book_type: fake.random.word(),
       pages: fake.random.number({ max: 3000 }),
       publishDate: fake.date.past(),

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -29,6 +29,7 @@ CREATE TABLE book (
   alibris TEXT NOT NULL,
   betterWorldBooks TEXT NOT NULL,
   indieBound TEXT NOT NULL,
+  worldcat TEXT NOT NULL,
   book_type TEXT NOT NULL,
   pages INTEGER NOT NULL,
   publishDate TEXT NOT NULL,


### PR DESCRIPTION
I incorrectly thought the worldcat column was not being used, so I originally omitted it. Last night I discovered where it was being used and reimplemented it and the (originally missing) code to assign the worldcat value.